### PR TITLE
fix: Object Storage fixes

### DIFF
--- a/configs/blacksd/object-storage/terragrunt.hcl
+++ b/configs/blacksd/object-storage/terragrunt.hcl
@@ -21,7 +21,8 @@ inputs = {
     "velero" = {
       storage_tier         = "Standard"
       versioning           = "Disabled"
-      lifecycle            = "90 days, delete"
+      auto_tiering         = "InfrequentAccess"
+      lifecycle            = "60 days, delete"
       create_s3_access_key = true
     }
   }

--- a/configs/blacksd/object-storage/terragrunt.hcl
+++ b/configs/blacksd/object-storage/terragrunt.hcl
@@ -12,12 +12,9 @@ dependency "oci-oke" {
 }
 
 inputs = {
+  # Grant access
+  oke_compartment_id                 = dependency.oci-oke.outputs.oke_compartment_ocid
   oke_iam_dynamic_group_workers_name = dependency.oci-oke.outputs.oke_iam_dynamic_group_workers_name
-
-  # Vault coordinates to store the Bucket secrets
-  oke_compartment_id       = dependency.oci-oke.outputs.oke_compartment_ocid
-  externalsecrets_key_id   = dependency.oci-oke.outputs.oke_external_secrets_key_ocid
-  externalsecrets_vault_id = dependency.oci-oke.outputs.oke_vault_ocid
 
   # https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm#objectstorage
   oci_buckets = {

--- a/configs/blacksd/object-storage/terragrunt.hcl
+++ b/configs/blacksd/object-storage/terragrunt.hcl
@@ -19,9 +19,9 @@ inputs = {
   # https://docs.oracle.com/en-us/iaas/Content/FreeTier/freetier_topic-Always_Free_Resources.htm#objectstorage
   oci_buckets = {
     "velero" = {
-      storage_tier         = "Archive"
+      storage_tier         = "Standard"
       versioning           = "Disabled"
-      retention            = "90 days"
+      lifecycle            = "90 days, delete"
       create_s3_access_key = true
     }
   }

--- a/modules/object-storage/README.md
+++ b/modules/object-storage/README.md
@@ -27,10 +27,12 @@ This module is about creating Object Storage buckets, in Oracle Cloud and (futur
 | [oci_identity_policy.allow_oke_workers_externalsecrets_vault_object_storage](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_identity_policy.allow_user_bucket_access](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_identity_policy.objecstorage_allow_kms_access](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
+| [oci_identity_policy.objecstorage_allow_lifecycle_rules](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_identity_user.bucket_user](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_user) | resource |
 | [oci_kms_key.object_storage_encription_key](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/kms_key) | resource |
 | [oci_kms_vault.this](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/kms_vault) | resource |
 | [oci_objectstorage_bucket.this](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/objectstorage_bucket) | resource |
+| [oci_objectstorage_object_lifecycle_policy.this](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/objectstorage_object_lifecycle_policy) | resource |
 | [oci_vault_secret.s3_buckets_credentials](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/vault_secret) | resource |
 | [oci_objectstorage_namespace.this](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/data-sources/objectstorage_namespace) | data source |
 
@@ -38,7 +40,7 @@ This module is about creating Object Storage buckets, in Oracle Cloud and (futur
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_oci_buckets"></a> [oci\_buckets](#input\_oci\_buckets) | A map of a buckets to create in Oracle Cloud. Bucket name is the key. | <pre>map(object({<br/>    # Standard, Archive<br/>    storage_tier : string,<br/>    # Disabled, Enabled, Suspended<br/>    versioning : string,<br/>    access_type : optional(string, "NoPublicAccess"),<br/>    auto_tiering : optional(string, "Disabled"),<br/>    object_events_enabled : optional(bool, false),<br/>    retention : optional(string),<br/>    create_s3_access_key : optional(bool, false),<br/>    store_s3_credentials_in_vault : optional(bool, true),<br/>    grant_oke_workers_access : optional(bool, false)<br/>  }))</pre> | n/a | yes |
+| <a name="input_oci_buckets"></a> [oci\_buckets](#input\_oci\_buckets) | A map of a buckets to create in Oracle Cloud. Bucket name is the key. | <pre>map(object({<br/>    # Standard, Archive<br/>    storage_tier : string,<br/>    # Disabled, Enabled, Suspended<br/>    versioning : string,<br/>    access_type : optional(string, "NoPublicAccess"),<br/>    auto_tiering : optional(string, "Disabled"),<br/>    object_events_enabled : optional(bool, false),<br/>    retention : optional(string),<br/>    lifecycle : optional(string),<br/>    create_s3_access_key : optional(bool, false),<br/>    store_s3_credentials_in_vault : optional(bool, true),<br/>    grant_oke_workers_access : optional(bool, false)<br/>  }))</pre> | n/a | yes |
 | <a name="input_oke_iam_dynamic_group_workers_name"></a> [oke\_iam\_dynamic\_group\_workers\_name](#input\_oke\_iam\_dynamic\_group\_workers\_name) | The OKE IAM dynamic group name for workers | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The OCI region name | `string` | n/a | yes |
 | <a name="input_tenancy_ocid"></a> [tenancy\_ocid](#input\_tenancy\_ocid) | The OCI Tenancy ID | `string` | n/a | yes |

--- a/modules/object-storage/README.md
+++ b/modules/object-storage/README.md
@@ -24,6 +24,7 @@ This module is about creating Object Storage buckets, in Oracle Cloud and (futur
 | [oci_identity_compartment.object_storage](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_compartment) | resource |
 | [oci_identity_customer_secret_key.bucket_secret_key](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_customer_secret_key) | resource |
 | [oci_identity_policy.allow_oke_workers_buckets](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
+| [oci_identity_policy.allow_oke_workers_externalsecrets_vault_object_storage](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_identity_policy.allow_user_bucket_access](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_identity_policy.objecstorage_allow_kms_access](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_identity_user.bucket_user](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_user) | resource |
@@ -37,10 +38,7 @@ This module is about creating Object Storage buckets, in Oracle Cloud and (futur
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_externalsecrets_key_id"></a> [externalsecrets\_key\_id](#input\_externalsecrets\_key\_id) | The OCID of the OKE ExternalSecrets encryption key | `string` | n/a | yes |
-| <a name="input_externalsecrets_vault_id"></a> [externalsecrets\_vault\_id](#input\_externalsecrets\_vault\_id) | The OCID of the vault containing the OKE ExternalSecrets encryption key | `string` | n/a | yes |
 | <a name="input_oci_buckets"></a> [oci\_buckets](#input\_oci\_buckets) | A map of a buckets to create in Oracle Cloud. Bucket name is the key. | <pre>map(object({<br/>    # Standard, Archive<br/>    storage_tier : string,<br/>    # Disabled, Enabled, Suspended<br/>    versioning : string,<br/>    access_type : optional(string, "NoPublicAccess"),<br/>    auto_tiering : optional(string, "Disabled"),<br/>    object_events_enabled : optional(bool, false),<br/>    retention : optional(string),<br/>    create_s3_access_key : optional(bool, false),<br/>    store_s3_credentials_in_vault : optional(bool, true),<br/>    grant_oke_workers_access : optional(bool, false)<br/>  }))</pre> | n/a | yes |
-| <a name="input_oke_compartment_id"></a> [oke\_compartment\_id](#input\_oke\_compartment\_id) | The OCID of the compartment to create the OKE resources in | `string` | n/a | yes |
 | <a name="input_oke_iam_dynamic_group_workers_name"></a> [oke\_iam\_dynamic\_group\_workers\_name](#input\_oke\_iam\_dynamic\_group\_workers\_name) | The OKE IAM dynamic group name for workers | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The OCI region name | `string` | n/a | yes |
 | <a name="input_tenancy_ocid"></a> [tenancy\_ocid](#input\_tenancy\_ocid) | The OCI Tenancy ID | `string` | n/a | yes |
@@ -52,4 +50,5 @@ This module is about creating Object Storage buckets, in Oracle Cloud and (futur
 | <a name="output_object_storage_compartment_ocid"></a> [object\_storage\_compartment\_ocid](#output\_object\_storage\_compartment\_ocid) | The Object Storage compartmnent's OCID | `"ocid1.compartment.oc1..aaaaaaaafdhn4u7r4g97ffh5gnxxakovn80f350220w7nqdjx9o0fgsb8o1e"` | no |
 | <a name="output_s3_buckets_credentials_secret_names"></a> [s3\_buckets\_credentials\_secret\_names](#output\_s3\_buckets\_credentials\_secret\_names) | The OCI Vault secret name and keys for all S3-compatible credentials | <pre>{<br/>  "velero": {<br/>    "secret_key": "s3_credentials",<br/>    "secret_name": "S3CredentialsVelero"<br/>  }<br/>}</pre> | no |
 | <a name="output_s3_credentials"></a> [s3\_credentials](#output\_s3\_credentials) | S3 Compatibility Layer credentials | `<sensitive>` | yes |
+| <a name="output_s3_vault"></a> [s3\_vault](#output\_s3\_vault) | Parameters to configure a [Cluster]SecretStore | `"null"` | no |
 <!-- END_TF_DOCS -->

--- a/modules/object-storage/oci-buckets.keys.tf
+++ b/modules/object-storage/oci-buckets.keys.tf
@@ -17,8 +17,8 @@ resource "oci_identity_policy" "allow_user_bucket_access" {
   name        = "allow_${oci_identity_user.bucket_user[each.key].name}_write_bucket_${each.key}"
   description = "Policy to allow S3 access for user ${oci_identity_user.bucket_user[each.key].name} to access bucket ${each.key}"
   statements = [
-    "Allow any-user to use buckets in compartment id ${oci_identity_compartment.object_storage.id} where all { target.bucket.name='${each.key}', request.user.id ='${oci_identity_user.bucket_user[each.key].name}' }",
-    "Allow any-user to manage objects in compartment id ${oci_identity_compartment.object_storage.id} where all { target.bucket.name='${each.key}', request.user.id ='${oci_identity_user.bucket_user[each.key].name}' }"
+    "Allow any-user to use buckets in compartment id ${oci_identity_compartment.object_storage.id} where all { target.bucket.name='${each.key}', request.user.id ='${oci_identity_user.bucket_user[each.key].id}' }",
+    "Allow any-user to manage objects in compartment id ${oci_identity_compartment.object_storage.id} where all { target.bucket.name='${each.key}', request.user.id ='${oci_identity_user.bucket_user[each.key].id}' }"
   ]
 
   # freeform_tags = { "IAM-UserInfo.UserType" = "robot" }

--- a/modules/object-storage/oci-kms.tf
+++ b/modules/object-storage/oci-kms.tf
@@ -51,7 +51,7 @@ resource "oci_identity_policy" "objecstorage_allow_kms_access" {
   compartment_id = var.tenancy_ocid
 
   name        = "allow_object_storage_key_access"
-  description = "Policy to allow bucket Object Storage service to access KMS key ID used for bucket encryption"
+  description = "Policy to allow Object Storage service to access KMS key ID used for bucket encryption"
   statements = [
     "allow service objectstorage-${var.region} to use keys in compartment id ${oci_identity_compartment.object_storage.id} where target.key.id = '${oci_kms_key.object_storage_encription_key.id}'"
   ]

--- a/modules/object-storage/oci-kms.tf
+++ b/modules/object-storage/oci-kms.tf
@@ -56,3 +56,16 @@ resource "oci_identity_policy" "objecstorage_allow_kms_access" {
     "allow service objectstorage-${var.region} to use keys in compartment id ${oci_identity_compartment.object_storage.id} where target.key.id = '${oci_kms_key.object_storage_encription_key.id}'"
   ]
 }
+
+resource "oci_identity_policy" "allow_oke_workers_externalsecrets_vault_object_storage" {
+  compartment_id = oci_identity_compartment.object_storage.id
+
+  name        = "allow_nodes_externalsecrets_vault_oke"
+  description = "Policy to allow OKE nodes in group '${var.oke_iam_dynamic_group_workers_name}' to use the ExternalSecrets encryption key and access secrets for read (sync) and write (create)"
+  statements = [
+    "Allow dynamic-group ${var.oke_iam_dynamic_group_workers_name} to read secret-family in compartment id ${oci_identity_compartment.object_storage.id}",                                                                     # INFO: Needed for secret read on a broader set of items
+    "Allow dynamic-group ${var.oke_iam_dynamic_group_workers_name} to use vaults in compartment id ${oci_identity_compartment.object_storage.id} where ALL {target.vault.id = '${oci_kms_vault.this.id}'}",                    # INFO: Needed for PushSecrets create privileges
+    "Allow dynamic-group ${var.oke_iam_dynamic_group_workers_name} to manage secrets in compartment id ${oci_identity_compartment.object_storage.id}",                                                                         # INFO: Needed for PushSecrets create privileges
+    "Allow dynamic-group ${var.oke_iam_dynamic_group_workers_name} to use keys in compartment id ${oci_identity_compartment.object_storage.id} where ALL {target.key.id = '${oci_kms_key.object_storage_encription_key.id}'}", # INFO: Needed for encrypt/decrypt operations
+  ]
+}

--- a/modules/oci-oke/README.md
+++ b/modules/oci-oke/README.md
@@ -77,7 +77,7 @@ TODO: explain the subnetting logic.
 | [oci_identity_policy.allow_oke_mek](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_identity_policy.allow_oke_nek](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_identity_policy.allow_oke_nodes_update_self](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
-| [oci_identity_policy.allow_oke_workers_externalsecrets](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
+| [oci_identity_policy.allow_oke_workers_externalsecrets_vault_oke](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/identity_policy) | resource |
 | [oci_kms_key.oke_external_secrets_key](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/kms_key) | resource |
 | [oci_kms_key.oke_master_encryption_key](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/kms_key) | resource |
 | [oci_kms_key.oke_node_encryption_key](https://registry.terraform.io/providers/oracle/oci/6.26.0/docs/resources/kms_key) | resource |

--- a/modules/oci-oke/oke.kms.tf
+++ b/modules/oci-oke/oke.kms.tf
@@ -116,10 +116,10 @@ resource "oci_kms_key" "oke_external_secrets_key" {
 
 # NOTE: I know, it would be nice to have a per-workload permissions model, but that requires an Enhanced-type OKE cluster, and that's not cheap!
 # INFO: Useful reference: https://docs.oracle.com/en-us/iaas/Content/Identity/policyreference/keypolicyreference.htm#Details_for_the_Vault_Service
-resource "oci_identity_policy" "allow_oke_workers_externalsecrets" {
+resource "oci_identity_policy" "allow_oke_workers_externalsecrets_vault_oke" {
   compartment_id = oci_identity_compartment.oke.id
 
-  name        = "allow_nodes_externalsecrets"
+  name        = "allow_nodes_externalsecrets_vault_oke"
   description = "Policy to allow nodes Compartment '${oci_identity_compartment.oke.name}' to use the ExternalSecrets encryption key and access secrets for read (sync) and write (create)"
   statements = [
     "Allow dynamic-group ${oci_identity_dynamic_group.all_oke_workers.name} to read secret-family in compartment id ${oci_identity_compartment.oke.id}",                                                                # INFO: Needed for secret read on a broader set of items


### PR DESCRIPTION
Fix a bunch of things, including:
- `Archive` tier isn't OK for the `velero` bucket
- retention rules and lifecycle rules aren't the same thing
- IAM user policy isn't correct
- need a new IAM policy to allow object handling from the service b/c of the lifecycle rules